### PR TITLE
Add link to JSAPI resources ember page

### DIFF
--- a/front-end/technologies/ember/README.md
+++ b/front-end/technologies/ember/README.md
@@ -12,16 +12,12 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-You can combine ArcGIS API for JavaScript with Ember in your developments,
-we will show you how in this page.
+See the [ArcGIS API resources Ember page](https://github.com/Esri/jsapi-resources/tree/master/frameworks/ember) for links to libraries and example applications that use the ArcGIS API for JavaScript in Ember applications.
 
-* Ember | Follow: [@ffaubry](https://github.com/ffaubry) & [@odoe](https://github.com/odoe) & [@dbouwman](https://github.com/dbouwman)
-  * [Ember CLI Addon for using AMD libraries](https://github.com/Esri/ember-cli-amd)
-
-[ArcGIS API for JavaScript Using it with EmberJS](http://www.esri.com/videos/watch?playlistid=series_259&channelid=LegacyVideo&isLegacy=true&title=2016-esri-developer-summit:-javascript-tech-sessions)
+* Ember | Follow: [@ffaubry](https://github.com/ffaubry) & [@odoe](https://github.com/odoe) & [@dbouwman](https://github.com/dbouwman) & [@tomwayson](https://github.com/tomwayson)
 
 ## Community
-* If you need help with a specific plugin/project try at the repository issues
+* If you need help with any of the above addons/applications, try at the repository issues
 
 ## People you should know
 Please find the ArcGIS Experts (story tellers and developers) on this topic here: [https://esri-es.github.io/arcgis-experts/?topic=EmberJS](https://esri-es.github.io/arcgis-experts/?topic=EmberJS)


### PR DESCRIPTION
@hhkaos - I ❤️ this repo.

In order to avoid duplication of maintenance w/ the frameworks pages under https://github.com/Esri/jsapi-resources/tree/master/frameworks/ I'd like to propose this general pattern: 
- for info on using the framework _w/ the ArcGIS API for JavaScript_  jsapi-resources should be the primary source, and I think the framework's page on this repo should link to the jsapi-resources page
- for any additional links on using that framework with the ArcGIS API for JavaScript that aren't included for whatever reason on the "official" jsapi-resources page can be listed on the corresponding page in this repo.
- links to resources that do **not** use the the ArcGIS API for JavaScript (i.e. info on using the framework w/ esri-leaflet, etc), should _only_ be listed in this repo

All of the framework pages in jsapi-resources already link to their counterparts in this repo - although maybe they should link to the gh-pages site?

What do you think?
